### PR TITLE
Replace KEY_ constants with PAD_ constants from NESLib

### DIFF
--- a/cnrom/main.c
+++ b/cnrom/main.c
@@ -74,7 +74,7 @@ int main() {
 	while (1) {
 		ctrl = joy_read(0);
 
-		if (ctrl & KEY_START && !(prevctrl & KEY_START)) {
+		if (ctrl & PAD_START && !(prevctrl & PAD_START)) {
 			state++;
 			state %= 5;
 

--- a/ctrltest.c
+++ b/ctrltest.c
@@ -17,14 +17,14 @@ int main() {
 		gotoy(0);
 
 		cprintf("Keys: %s%s%s%s%s%s%s%s                           ",
-			a & KEY_UP ? "up " : "",
-			a & KEY_DOWN ? "down " : "",
-			a & KEY_LEFT ? "left " : "",
-			a & KEY_RIGHT ? "right " : "",
-			a & KEY_A ? "A " : "",
-			a & KEY_B ? "B " : "",
-			a & KEY_SELECT ? "select " : "",
-			a & KEY_START ? "start " : "");
+			a & PAD_UP ? "up " : "",
+			a & PAD_DOWN ? "down " : "",
+			a & PAD_LEFT ? "left " : "",
+			a & PAD_RIGHT ? "right " : "",
+			a & PAD_A ? "A " : "",
+			a & PAD_B ? "B " : "",
+			a & PAD_SELECT ? "select " : "",
+			a & PAD_START ? "start " : "");
 	}
 
 	return 0;

--- a/move.c
+++ b/move.c
@@ -69,13 +69,13 @@ int main() {
 		prevy = y;
 		prevx = x;
 
-		if (a & KEY_LEFT && x)
+		if (a & PAD_LEFT && x)
 			x--;
-		if (a & KEY_RIGHT && x < 31)
+		if (a & PAD_RIGHT && x < 31)
 			x++;
-		if (a & KEY_UP && y > 1)
+		if (a & PAD_UP && y > 1)
 			y--;
-		if (a & KEY_DOWN && y < 28)
+		if (a & PAD_DOWN && y < 28)
 			y++;
 	}
 


### PR DESCRIPTION
These constants are not defined in a stock cc65 build, and NESLib has its own constants of the same thing under a different name.